### PR TITLE
Use "chunk" term instead of "packet".

### DIFF
--- a/content/articles/2018/2018-07-03-inlining-literally-everything-for-better-performance.md
+++ b/content/articles/2018/2018-07-03-inlining-literally-everything-for-better-performance.md
@@ -22,7 +22,7 @@ There are a few nuances to how HTTP works that impact web performance.
 
 1. Both CSS and JavaScript are render blocking, so when a browser comes across a file of that type in the HTML, it waits until it's finished before rendering anything else.
 2. Downloading multiple smaller files is slower than downloading a single file of the same combined size, because of the lookups, handshakes, and "queuing process" that happens. This isn't true anymore with HTTP2, but older browsers and unencrypted sites don't support it.
-3. Data for any particular file is transferred in small chunks of about 14kb. So if you have, for example, a 250kb image, 18 small packets of data will be sent one-at-a-time for it.
+3. Data for any particular file is transferred in small chunks of about 14kb. So if you have, for example, a 250kb image, 18 small chunks of data will be sent one-at-a-time for it.
 
 Because of these things, if the combined weight of your above-the-fold (not a real thing) CSS, HTML, and JS is 14kb or less (after minifying and gzipping), it's more performant to embed it all into the HTML document.
 

--- a/content/articles/2019/2019-11-08-how-i-setup-my-vanilla-js-projects.md
+++ b/content/articles/2019/2019-11-08-how-i-setup-my-vanilla-js-projects.md
@@ -101,7 +101,7 @@ It's a super lightweight, easy way to do code-splitting without messing with a c
 
 When it comes to web performance, 14kb is a magic number. That's the approximate number of bytes in a single round trip HTTP request.
 
-Servers send files to the browser in small packets rather than all-at-once. If you have a 20kb JavaScript file, that takes two round trips to get to the browser.
+Servers send files to the browser in small chunks rather than all-at-once. If you have a 20kb JavaScript file, that takes two round trips to get to the browser.
 
 The more round trips, the slower the site (generally speaking).
 

--- a/content/articles/2022/2022-02-23-how-to-make-an-mpa-as-fast-as-an-spa.md
+++ b/content/articles/2022/2022-02-23-how-to-make-an-mpa-as-fast-as-an-spa.md
@@ -48,7 +48,7 @@ Caching can help a lot with this, but flat HTML files are just so absurdly fast.
 
 Severs respond to HTTP requests in 14kb chunks. 
 
-If you have, for example, a 250kb image, 18 small packets of data will be sent one-at-a-time for it: 17 packets 14kb in size, plus one not-quite-12kb one.
+If you have, for example, a 250kb image, 18 small chunks of data will be sent one-at-a-time for it: 17 chunks 14kb in size, plus one not-quite-12kb one.
 
 Each HTTP request adds a bit of latency to the rendering process, as browsers and servers do a little handshake dance with each other.
 


### PR DESCRIPTION
Thanks for your write-ups about how to load websites fast. I've use some similar techniques, including trying to get the "above-the-fold" to render within the first 14kb of data sent from the server.

Technically the 14kb "initial congestion window" is 10 "packets", about 1400 bytes each, not a single 14kb "packet", so I think it's best to avoid using "packet" to describe the 14kb, as it's actually 10 "packets". You used "chunk" elsewhere so it might make sense to use that everywhere.

(Also, technically the "congestion window" doubles every successful round trip, so it's 14kb for the first round trip, then 28kb, etc. So it's more like 5 round-trips for a 250kb image (assuming no packet loss), but I suppose the main point is that it's more than one round trip. https://developer.mozilla.org/en-US/docs/Web/Performance/How_browsers_work#tcp_slow_start_14kb_rule (That link uses the term "packet" the way you're using it so maybe it's more actually more common than I thought?)